### PR TITLE
fix: start for loop at d=1 to preserve reflective boundary on primary axis

### DIFF
--- a/src/UnitTests/src/testBoundaryConditions.cpp
+++ b/src/UnitTests/src/testBoundaryConditions.cpp
@@ -213,7 +213,7 @@ public:
     ReflectBoundaryConditionTest() {
         this->fieldSolver->setReflectBoundaryConditions(this->axis);
 
-        for (int d = 0; d < 3; d++) {
+        for (int d = 1; d < 3; d++) {
             int dim = ((int)this->axis + d) % 3;
             if (dim < this->grid->dimensionality)
                 this->fieldSolver->setPeriodicalBoundaryConditions((CoordinateEnum)dim);


### PR DESCRIPTION
## Summary

Fix a bug in `testBoundaryConditions.cpp` where the `for` loop starts at `d=0`, which overrides the primary axis's reflective boundary condition (set by `setReflectBoundaryConditions`) with periodical boundary conditions.

## Root Cause

`ReflectBoundaryConditionTest` constructor calls `setReflectBoundaryConditions(this->axis)` then immediately enters a loop starting at `d=0`:
```c++
for (int d = 0; d < 3; d++) {
    int dim = ((int)this->axis + d) % 3;
    this->fieldSolver->setPeriodicalBoundaryConditions((CoordinateEnum)dim);
}
```
When `d=0`, `dim = this->axis`, so the primary axis's reflective condition is overwritten with periodical.

## Fix

Start the loop at `d=1` instead of `d=0`:
```c++
for (int d = 1; d < 3; d++) {
```

The test passes because reflective and periodical boundary conditions are equivalent in this test's specific structure, but the fix makes the test logically correct.

## Testing

- The existing test suite should continue to pass.
- The fix is a 1-line change (single commit, GH007 compliant).

Fixes issue #35.