### PR TITLE
Directional Field Boundary Conditions

### DIFF
--- a/src/Modules/Field/include/Fdtd.h
+++ b/src/Modules/Field/include/Fdtd.h
@@ -18,6 +18,7 @@ namespace pfc {
             using FieldGeneratorType = FieldGeneratorFdtd;
             using PeriodicalBoundaryConditionType = PeriodicalBoundaryConditionFdtd;
             using ReflectBoundaryConditionType = ReflectBoundaryConditionFdtd;
+            using ReflectBoundaryConditionMonoDirectionType = ReflectBoundaryConditionMonoDirectionFdtd;
         };
     }
     
@@ -31,6 +32,7 @@ namespace pfc {
         using FieldGeneratorType = fdtd::SchemeParams::FieldGeneratorType;
         using PeriodicalBoundaryConditionType = fdtd::SchemeParams::PeriodicalBoundaryConditionType;
         using ReflectBoundaryConditionType = fdtd::SchemeParams::ReflectBoundaryConditionType;
+        using ReflectBoundaryConditionMonoDirectionType = fdtd::SchemeParams::ReflectBoundaryConditionMonoDirectionType;
 
         FDTD(GridType* grid, FP dt);
 
@@ -47,6 +49,7 @@ namespace pfc {
 
         void setReflectBoundaryConditions();
         void setReflectBoundaryConditions(CoordinateEnum axis);
+        void setReflectBoundaryConditions(CoordinateEnum axis, SideEnum side);
 
         void setTimeStep(FP dt);
 
@@ -108,29 +111,40 @@ namespace pfc {
     inline void FDTD::setPeriodicalBoundaryConditions()
     {
         for (int d = 0; d < this->grid->dimensionality; d++)
-            this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, (CoordinateEnum)d));
     }
 
     inline void FDTD::setPeriodicalBoundaryConditions(CoordinateEnum axis)
     {
         if ((int)axis < this->grid->dimensionality)
-            this->boundaryConditions[(int)axis].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[(int)axis].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, axis));
     }
 
     inline void FDTD::setReflectBoundaryConditions()
     {
         for (int d = 0; d < this->grid->dimensionality; d++)
-            this->boundaryConditions[d].reset(new ReflectBoundaryConditionType(
+            this->boundaryConditions[d].first.reset(new ReflectBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd));
     }
 
     inline void FDTD::setReflectBoundaryConditions(CoordinateEnum axis)
     {
         if ((int)axis < this->grid->dimensionality)
-            this->boundaryConditions[(int)axis].reset(new ReflectBoundaryConditionType(
+            this->boundaryConditions[(int)axis].first.reset(new ReflectBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, axis));
+    }
+
+    inline void FDTD::setReflectBoundaryConditions(CoordinateEnum axis, SideEnum side)
+    {
+        if (!((int)axis < this->grid->dimensionality))
+            return;
+
+        auto& b_condition_p = (side == SideEnum::RIGHT) ? (this->boundaryConditions[(int)axis].first) : 
+                                                          (this->boundaryConditions[(int)axis].second);
+        b_condition_p.reset(new ReflectBoundaryConditionMonoDirectionType(
+            this->grid, this->domainIndexBegin, this->domainIndexEnd, axis, side));
     }
 
     inline void FDTD::setTimeStep(FP dt)
@@ -397,14 +411,31 @@ namespace pfc {
     inline void FDTD::saveBoundaryConditions(std::ostream& ostr)
     {
         for (int d = 0; d < 3; d++) {
-            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].get()) ? 1 : 0;
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
             ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
-            int isReflectBC = dynamic_cast<ReflectBoundaryConditionType*>(this->boundaryConditions[d].get()) ? 1 : 0;
+            int isReflectBC = dynamic_cast<ReflectBoundaryConditionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
             ostr.write((char*)&isReflectBC, sizeof(isReflectBC));
 
-            if (this->boundaryConditions[d])
-                this->boundaryConditions[d]->save(ostr);
+            int isMonoDirectionReflectBC = dynamic_cast<ReflectBoundaryConditionMonoDirectionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
+            ostr.write((char*)&isMonoDirectionReflectBC, sizeof(isMonoDirectionReflectBC));
+
+            if (this->boundaryConditions[d].first)
+                this->boundaryConditions[d].first->save(ostr);
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            int isReflectBC = dynamic_cast<ReflectBoundaryConditionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isReflectBC, sizeof(isReflectBC));
+
+            int isMonoDirectionReflectBC = dynamic_cast<ReflectBoundaryConditionMonoDirectionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isMonoDirectionReflectBC, sizeof(isMonoDirectionReflectBC));
+
+            if (this->boundaryConditions[d].second)
+                this->boundaryConditions[d].second->save(ostr);
         }
     }
 
@@ -417,15 +448,50 @@ namespace pfc {
             int isReflectBC = 0;
             istr.read((char*)&isReflectBC, sizeof(isReflectBC));
 
+            int isMonoDirectionReflectBC = 0;
+            istr.read((char*)&isMonoDirectionReflectBC, sizeof(isMonoDirectionReflectBC));
+
             if (isPeriodicalBC) {
-                this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+                this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                     this->grid, this->domainIndexBegin, this->domainIndexEnd));
-                this->boundaryConditions[d]->load(istr);
+                this->boundaryConditions[d].first->load(istr);
             }
             else if (isReflectBC) {
-                this->boundaryConditions[d].reset(new ReflectBoundaryConditionType(
+                this->boundaryConditions[d].first.reset(new ReflectBoundaryConditionType(
                     this->grid, this->domainIndexBegin, this->domainIndexEnd));
-                this->boundaryConditions[d]->load(istr);
+                this->boundaryConditions[d].first->load(istr);
+            }
+            else if (isMonoDirectionReflectBC) {
+                this->boundaryConditions[d].first.reset(new ReflectBoundaryConditionMonoDirectionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].first->load(istr);
+            }
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = 0;
+            istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            int isReflectBC = 0;
+            istr.read((char*)&isReflectBC, sizeof(isReflectBC));
+
+            int isMonoDirectionReflectBC = 0;
+            istr.read((char*)&isMonoDirectionReflectBC, sizeof(isMonoDirectionReflectBC));
+
+            if (isPeriodicalBC) {
+                this->boundaryConditions[d].second.reset(new PeriodicalBoundaryConditionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
+            }
+            else if (isReflectBC) {
+                this->boundaryConditions[d].second.reset(new ReflectBoundaryConditionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
+            }
+            else if (isMonoDirectionReflectBC) {
+                this->boundaryConditions[d].second.reset(new ReflectBoundaryConditionMonoDirectionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
             }
         }
     }

--- a/src/Modules/Field/include/FieldBoundaryConditionFdtd.h
+++ b/src/Modules/Field/include/FieldBoundaryConditionFdtd.h
@@ -119,4 +119,74 @@ namespace pfc
                 this->grid->Ez(indexR) = (FP)0.0;
             }
     }
+
+    class ReflectBoundaryConditionMonoDirectionFdtd : public FieldBoundaryCondition<YeeGrid>
+    {
+    protected:
+        SideEnum direction_;
+
+    public:
+
+        ReflectBoundaryConditionMonoDirectionFdtd(YeeGrid* grid,
+            Int3 leftBorderIndex, Int3 rightBorderIndex, CoordinateEnum axis, SideEnum direction) :
+            FieldBoundaryCondition(grid, leftBorderIndex, rightBorderIndex, axis), direction_(direction)
+        {}
+
+        // constructor for loading
+        explicit ReflectBoundaryConditionMonoDirectionFdtd(YeeGrid* grid,
+            Int3 leftBorderIndex, Int3 rightBorderIndex) :
+            FieldBoundaryCondition(grid, leftBorderIndex, rightBorderIndex)
+        {}
+
+        void generateB(FP time) override {}
+        void generateE(FP time) override;
+
+        virtual void save(std::ostream& ostr);
+        virtual void load(std::istream& istr);
+
+        FieldBoundaryCondition<YeeGrid>* createInstance(
+            YeeGrid* grid, Int3 leftBorderIndex, Int3 rightBorderIndex, CoordinateEnum axis) override {
+            return new ReflectBoundaryConditionMonoDirectionFdtd(grid, leftBorderIndex, rightBorderIndex, axis, direction_);
+        }
+    };
+
+    inline void ReflectBoundaryConditionMonoDirectionFdtd::generateE(FP time)
+    {
+        int dim0 = (int)axis;
+        int dim1 = (dim0 + 1) % 3;
+        int dim2 = (dim0 + 2) % 3;
+        int begin1 = 0;
+        int begin2 = 0;
+        int end1 = this->grid->numCells[dim1];
+        int end2 = this->grid->numCells[dim2];
+
+        OMP_FOR_COLLAPSE()
+        for (int j = begin1; j < end1; j++)
+            for (int k = begin2; k < end2; k++)
+            {
+                Int3 index;
+                index[dim1] = j;
+                index[dim2] = k;
+
+                index[dim0] = (direction_ == SideEnum::RIGHT) ? (this->rightBorderIndex[dim0] - 1) : (this->leftBorderIndex[dim0] - 1);
+
+                this->grid->Ex(index) = (FP)0.0;
+                this->grid->Ey(index) = (FP)0.0;
+                this->grid->Ez(index) = (FP)0.0;
+            }
+    }
+
+    inline void ReflectBoundaryConditionMonoDirectionFdtd::save(std::ostream& ostr)
+    {
+        FieldBoundaryCondition<YeeGrid>::save(ostr);
+
+        ostr.write((char*)&direction_, sizeof(direction_));
+    }
+
+    inline void ReflectBoundaryConditionMonoDirectionFdtd::load(std::istream& istr)
+    {
+        FieldBoundaryCondition<YeeGrid>::load(istr);
+
+        istr.read((char*)&direction_, sizeof(direction_));
+    }
 }

--- a/src/Modules/Field/include/FieldSolver.h
+++ b/src/Modules/Field/include/FieldSolver.h
@@ -96,7 +96,10 @@ namespace pfc {
         typename SchemeParams::GridType* grid = nullptr;
 
         std::unique_ptr<typename SchemeParams::PmlType> pml;
-        std::array<std::unique_ptr<FieldBoundaryCondition<typename SchemeParams::GridType>>, 3> boundaryConditions;
+        std::array<std::pair<   
+                             std::unique_ptr<FieldBoundaryCondition<typename SchemeParams::GridType>>, // +Axis
+                             std::unique_ptr<FieldBoundaryCondition<typename SchemeParams::GridType>> // -Axis
+                            >, 3> boundaryConditions;
         std::unique_ptr<typename SchemeParams::FieldGeneratorType> generator;
 
         // Index space being updated in non-pml area
@@ -157,16 +160,26 @@ namespace pfc {
     inline void FieldSolver<SchemeParams>::applyBoundaryConditionsB(FP time)
     {
         for (int d = 0; d < grid->dimensionality; d++)
-            if (boundaryConditions[d])
-                boundaryConditions[d]->generateB(time);
+        {
+            if (boundaryConditions[d].first)
+                boundaryConditions[d].first->generateB(time);
+
+            if (boundaryConditions[d].second)
+                boundaryConditions[d].second->generateB(time);
+        }
     }
 
     template<class SchemeParams>
     inline void FieldSolver<SchemeParams>::applyBoundaryConditionsE(FP time)
     {
         for (int d = 0; d < grid->dimensionality; d++)
-            if (boundaryConditions[d])
-                boundaryConditions[d]->generateE(time);
+        {
+            if (boundaryConditions[d].first)
+                boundaryConditions[d].first->generateE(time);
+
+            if (boundaryConditions[d].second)
+                boundaryConditions[d].second->generateE(time);
+        }
     }
 
     template<class SchemeParams>
@@ -245,9 +258,15 @@ namespace pfc {
     inline void FieldSolver<SchemeParams>::resetBoundaryConditions()
     {
         for (int d = 0; d < 3; d++)
-            if (this->boundaryConditions[d])
-                this->boundaryConditions[d].reset(this->boundaryConditions[d]->createInstance(this->grid,
-                    this->domainIndexBegin, this->domainIndexEnd, this->boundaryConditions[d]->axis));
+        {
+            if (this->boundaryConditions[d].first)
+                this->boundaryConditions[d].first.reset(this->boundaryConditions[d].first->createInstance(this->grid,
+                    this->domainIndexBegin, this->domainIndexEnd, this->boundaryConditions[d].first->axis));
+
+            if (this->boundaryConditions[d].second)
+                this->boundaryConditions[d].second.reset(this->boundaryConditions[d].second->createInstance(this->grid,
+                    this->domainIndexBegin, this->domainIndexEnd, this->boundaryConditions[d].second->axis));
+        }
     }
 
 

--- a/src/Modules/Field/include/Psatd.h
+++ b/src/Modules/Field/include/Psatd.h
@@ -90,7 +90,7 @@ namespace pfc {
     inline void PSATDT<ifPoisson>::setPeriodicalBoundaryConditions()
     {
         for (int d = 0; d < this->grid->dimensionality; d++)
-            this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, (CoordinateEnum)d));
     }
 
@@ -98,7 +98,7 @@ namespace pfc {
     inline void PSATDT<ifPoisson>::setPeriodicalBoundaryConditions(CoordinateEnum axis)
     {
         if ((int)axis < this->grid->dimensionality)
-            this->boundaryConditions[(int)axis].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[(int)axis].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, axis));
     }
 
@@ -298,11 +298,19 @@ namespace pfc {
     inline void PSATDT<ifPoisson>::saveBoundaryConditions(std::ostream& ostr)
     {
         for (int d = 0; d < 3; d++) {
-            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].get()) ? 1 : 0;
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
             ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
-            if (this->boundaryConditions[d])
-                this->boundaryConditions[d]->save(ostr);
+            if (this->boundaryConditions[d].first)
+                this->boundaryConditions[d].first->save(ostr);
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (this->boundaryConditions[d].second)
+                this->boundaryConditions[d].second->save(ostr);
         }
     }
 
@@ -314,9 +322,20 @@ namespace pfc {
             istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
             if (isPeriodicalBC) {
-                this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+                this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                     this->grid, this->domainIndexBegin, this->domainIndexEnd));
-                this->boundaryConditions[d]->load(istr);
+                this->boundaryConditions[d].first->load(istr);
+            }
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = 0;
+            istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (isPeriodicalBC) {
+                this->boundaryConditions[d].second.reset(new PeriodicalBoundaryConditionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
             }
         }
     }

--- a/src/Modules/Field/include/PsatdTimeStaggered.h
+++ b/src/Modules/Field/include/PsatdTimeStaggered.h
@@ -104,7 +104,7 @@ namespace pfc {
     inline void PSATDTimeStaggeredT<ifPoisson>::setPeriodicalBoundaryConditions()
     {
         for (int d = 0; d < this->grid->dimensionality; d++)
-            this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, (CoordinateEnum)d));
     }
 
@@ -112,7 +112,7 @@ namespace pfc {
     inline void PSATDTimeStaggeredT<ifPoisson>::setPeriodicalBoundaryConditions(CoordinateEnum axis)
     {
         if ((int)axis < this->grid->dimensionality)
-            this->boundaryConditions[(int)axis].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[(int)axis].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, axis));
     }
 
@@ -353,11 +353,19 @@ namespace pfc {
     inline void PSATDTimeStaggeredT<ifPoisson>::saveBoundaryConditions(std::ostream& ostr)
     {
         for (int d = 0; d < 3; d++) {
-            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].get()) ? 1 : 0;
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
             ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
-            if (this->boundaryConditions[d])
-                this->boundaryConditions[d]->save(ostr);
+            if (this->boundaryConditions[d].first)
+                this->boundaryConditions[d].first->save(ostr);
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (this->boundaryConditions[d].second)
+                this->boundaryConditions[d].second->save(ostr);
         }
     }
 
@@ -369,9 +377,20 @@ namespace pfc {
             istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
             if (isPeriodicalBC) {
-                this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+                this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                     this->grid, this->domainIndexBegin, this->domainIndexEnd));
-                this->boundaryConditions[d]->load(istr);
+                this->boundaryConditions[d].first->load(istr);
+            }
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = 0;
+            istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (isPeriodicalBC) {
+                this->boundaryConditions[d].second.reset(new PeriodicalBoundaryConditionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
             }
         }
     }

--- a/src/Modules/Field/include/Pstd.h
+++ b/src/Modules/Field/include/Pstd.h
@@ -86,14 +86,14 @@ namespace pfc {
     inline void PSTD::setPeriodicalBoundaryConditions()
     {
         for (int d = 0; d < this->grid->dimensionality; d++)
-            this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, (CoordinateEnum)d));
     }
 
     inline void PSTD::setPeriodicalBoundaryConditions(CoordinateEnum axis)
     {
         if ((int)axis < this->grid->dimensionality)
-            this->boundaryConditions[(int)axis].reset(new PeriodicalBoundaryConditionType(
+            this->boundaryConditions[(int)axis].first.reset(new PeriodicalBoundaryConditionType(
                 this->grid, this->domainIndexBegin, this->domainIndexEnd, axis));
     }
 
@@ -199,14 +199,24 @@ namespace pfc {
         this->loadBoundaryConditions(istr);
     }
 
+    // TO DO: Adjust boundary condition saving logic
+
     inline void PSTD::saveBoundaryConditions(std::ostream& ostr)
     {
         for (int d = 0; d < 3; d++) {
-            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].get()) ? 1 : 0;
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].first.get()) ? 1 : 0;
             ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
-            if (this->boundaryConditions[d])
-                this->boundaryConditions[d]->save(ostr);
+            if (this->boundaryConditions[d].first)
+                this->boundaryConditions[d].first->save(ostr);
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = dynamic_cast<PeriodicalBoundaryConditionType*>(this->boundaryConditions[d].second.get()) ? 1 : 0;
+            ostr.write((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (this->boundaryConditions[d].second)
+                this->boundaryConditions[d].second->save(ostr);
         }
     }
 
@@ -217,9 +227,20 @@ namespace pfc {
             istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
 
             if (isPeriodicalBC) {
-                this->boundaryConditions[d].reset(new PeriodicalBoundaryConditionType(
+                this->boundaryConditions[d].first.reset(new PeriodicalBoundaryConditionType(
                     this->grid, this->domainIndexBegin, this->domainIndexEnd));
-                this->boundaryConditions[d]->load(istr);
+                this->boundaryConditions[d].first->load(istr);
+            }
+        }
+
+        for (int d = 0; d < 3; d++) {
+            int isPeriodicalBC = 0;
+            istr.read((char*)&isPeriodicalBC, sizeof(isPeriodicalBC));
+
+            if (isPeriodicalBC) {
+                this->boundaryConditions[d].second.reset(new PeriodicalBoundaryConditionType(
+                    this->grid, this->domainIndexBegin, this->domainIndexEnd));
+                this->boundaryConditions[d].second->load(istr);
             }
         }
     }

--- a/src/UnitTests/src/testBoundaryConditions.cpp
+++ b/src/UnitTests/src/testBoundaryConditions.cpp
@@ -213,7 +213,7 @@ public:
     ReflectBoundaryConditionTest() {
         this->fieldSolver->setReflectBoundaryConditions(this->axis);
 
-        for (int d = 0; d < 3; d++) {
+        for (int d = 1; d < 3; d++) {
             int dim = ((int)this->axis + d) % 3;
             if (dim < this->grid->dimensionality)
                 this->fieldSolver->setPeriodicalBoundaryConditions((CoordinateEnum)dim);

--- a/src/UnitTests/src/testBoundaryConditions.cpp
+++ b/src/UnitTests/src/testBoundaryConditions.cpp
@@ -281,3 +281,81 @@ TYPED_TEST(ReflectBoundaryConditionTest, MixedPeriodicAndReflectBoundaryConditio
                 ASSERT_NEAR((expectedB - actualB).norm(), 0.0, this->maxError);
             }
 }
+
+
+template <class TTypeDefinitionsFieldTest>
+class ReflectBoundaryConditionMonoDirectionTest : public BoundaryConditionTest<TTypeDefinitionsFieldTest> {
+public:
+
+    ReflectBoundaryConditionMonoDirectionTest() {
+        this->fieldSolver->setReflectBoundaryConditions(this->axis, SideEnum::LEFT);
+        this->fieldSolver->setReflectBoundaryConditions(this->axis, SideEnum::RIGHT);
+
+        for (int d = 1; d < 3; d++) {
+            int dim = ((int)this->axis + d) % 3;
+            if (dim < this->grid->dimensionality)
+                this->fieldSolver->setPeriodicalBoundaryConditions((CoordinateEnum)dim);
+        }
+    }
+
+};
+
+typedef ::testing::Types <
+    TypeDefinitionsFieldTest<FDTD, 1, CoordinateEnum::x>,
+    TypeDefinitionsFieldTest<FDTD, 2, CoordinateEnum::x>,
+    TypeDefinitionsFieldTest<FDTD, 2, CoordinateEnum::y>,
+    TypeDefinitionsFieldTest<FDTD, 3, CoordinateEnum::x>,
+    TypeDefinitionsFieldTest<FDTD, 3, CoordinateEnum::y>,
+    TypeDefinitionsFieldTest<FDTD, 3, CoordinateEnum::z>
+> typesReflectMonoDirection;
+
+TYPED_TEST_CASE(ReflectBoundaryConditionMonoDirectionTest, typesReflectMonoDirection);
+
+TYPED_TEST(ReflectBoundaryConditionMonoDirectionTest, MixedPeriodicAndReflectBoundaryConditionTest)
+{
+    for (int step = 0; step < this->numSteps; ++step)
+    {
+        this->fieldSolver->updateFields();
+    }
+
+    // signal should be the same as at the beginning
+    // because signal is symmetric
+    FP startT = 0;
+
+    Int3 begin = this->fieldSolver->internalIndexBegin;
+    Int3 end = this->fieldSolver->internalIndexEnd;
+
+    for (int i = begin.x; i < end.x; ++i)
+        for (int j = begin.y; j < end.y; ++j)
+            for (int k = begin.z; k < end.z; ++k)
+            {
+                FP3 expectedE, actualE;
+                FP3 coords = this->grid->ExPosition(i, j, k);
+                expectedE.x = this->eTest(coords.x, coords.y, coords.z, startT).x;
+                coords = this->grid->EyPosition(i, j, k);
+                expectedE.y = this->eTest(coords.x, coords.y, coords.z, startT).y;
+                coords = this->grid->EzPosition(i, j, k);
+                expectedE.z = this->eTest(coords.x, coords.y, coords.z, startT).z;
+                actualE.x = this->grid->Ex(i, j, k);
+                actualE.y = this->grid->Ey(i, j, k);
+                actualE.z = this->grid->Ez(i, j, k);
+                ASSERT_NEAR((expectedE - actualE).norm(), 0.0, this->maxError);
+            }
+
+    for (int i = begin.x; i < end.x; ++i)
+        for (int j = begin.y; j < end.y; ++j)
+            for (int k = begin.z; k < end.z; ++k)
+            {
+                FP3 expectedB, actualB;
+                FP3 coords = this->grid->BxPosition(i, j, k);
+                expectedB.x = this->bTest(coords.x, coords.y, coords.z, startT).x;
+                coords = this->grid->ByPosition(i, j, k);
+                expectedB.y = this->bTest(coords.x, coords.y, coords.z, startT).y;
+                coords = this->grid->BzPosition(i, j, k);
+                expectedB.z = this->bTest(coords.x, coords.y, coords.z, startT).z;
+                actualB.x = this->grid->Bx(i, j, k);
+                actualB.y = this->grid->By(i, j, k);
+                actualB.z = this->grid->Bz(i, j, k);
+                ASSERT_NEAR((expectedB - actualB).norm(), 0.0, this->maxError);
+            }
+}

--- a/src/UnitTests/src/testSaveLoadGrid.cpp
+++ b/src/UnitTests/src/testSaveLoadGrid.cpp
@@ -401,26 +401,44 @@ public:
     }
 
     bool compareBC() {
-        PeriodicalBCType* bc1[3] = {
-            dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[0].get()),
-            dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[1].get()),
-            dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[2].get())
+        std::pair<PeriodicalBCType*, PeriodicalBCType*> bc1[3] = {
+            {   dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[0].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[0].second.get())},
+            {   dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[1].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[1].second.get())},
+            {   dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[2].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver->boundaryConditions[2].second.get())}
         };
 
-        PeriodicalBCType* bc2[3] = {
-            dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[0].get()),
-            dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[1].get()),
-            dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[2].get())
+        std::pair<PeriodicalBCType*, PeriodicalBCType*> bc2[3] = {
+            {   dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[0].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[0].second.get())},
+            {   dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[1].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[1].second.get())},
+            {   dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[2].first.get()), 
+                dynamic_cast<PeriodicalBCType*>(this->solver2->boundaryConditions[2].second.get())}
         };
 
-        if (!bc1[0] || !bc1[1] || !bc1[2]) return false;
-        if (!bc2[0] || !bc2[1] || !bc2[2]) return false;
+        if ((bc1[0].first != nullptr) != (bc2[0].first != nullptr) ) return false;
+        if ((bc1[1].first != nullptr) != (bc2[1].first != nullptr) ) return false;
+        if ((bc1[2].first != nullptr) != (bc2[2].first != nullptr) ) return false;
+
+        if ((bc1[0].second != nullptr) != (bc2[0].second != nullptr) ) return false;
+        if ((bc1[1].second != nullptr) != (bc2[1].second != nullptr) ) return false;
+        if ((bc1[2].second != nullptr) != (bc2[2].second != nullptr) ) return false;
 
         bool res = true;
         for (int d = 0; d < 3; d++) {
-            res = res && (bc1[d]->axis == bc2[d]->axis);
-            res = res && (bc1[d]->leftBorderIndex == bc2[d]->leftBorderIndex);
-            res = res && (bc1[d]->rightBorderIndex == bc2[d]->rightBorderIndex);
+            if (bc1[d].first) {
+                res = res && (bc1[d].first->axis == bc2[d].first->axis);
+                res = res && (bc1[d].first->leftBorderIndex == bc2[d].first->leftBorderIndex);
+                res = res && (bc1[d].first->rightBorderIndex == bc2[d].first->rightBorderIndex);
+            }
+            if (bc1[d].second) {
+                res = res && (bc1[d].second->axis == bc2[d].second->axis);
+                res = res && (bc1[d].second->leftBorderIndex == bc2[d].second->leftBorderIndex);
+                res = res && (bc1[d].second->rightBorderIndex == bc2[d].second->rightBorderIndex);
+            }
         }
 
         return res;
@@ -531,6 +549,48 @@ TYPED_TEST(SaveLoadSolverModulesTest, old_and_new_grid_solvers_and_modules_are_i
     ASSERT_TRUE(this->compareBC());
 }
 
+template <class TSolver>
+class SaveLoadSolverModulesMonoBCTest : public SaveLoadSolverModulesTest<TSolver> {
+public:
+    virtual void SetUp() override 
+    {
+        SaveLoadSolverModulesTest<TSolver>::SetUp();
+
+        this->solver->setReflectBoundaryConditions(CoordinateEnum::x, SideEnum::LEFT);
+        this->solver->setReflectBoundaryConditions(CoordinateEnum::x, SideEnum::RIGHT); 
+    }
+};
+
+typedef ::testing::Types<
+    FDTD
+> typesMonoDirectionBCSaveLoadSolverModulesTest;
+
+TYPED_TEST_CASE(SaveLoadSolverModulesMonoBCTest, typesMonoDirectionBCSaveLoadSolverModulesTest);
+
+TYPED_TEST(SaveLoadSolverModulesMonoBCTest, mono_direction_boundary_conditions)
+{
+    for (int step = 0; step < this->numSteps / 2; ++step)
+        this->solver->updateFields();
+
+    std::stringstream sstr;
+    this->saveGridAndSolver(sstr);
+
+    for (int step = 0; step < this->numSteps / 2; ++step)
+        this->solver->updateFields();
+
+    this->loadGridAndSolver(sstr);
+
+    ASSERT_FALSE(this->compareFields(this->maxAbsoluteError));
+
+    for (int step = 0; step < this->numSteps / 2; ++step)
+        this->solver2->updateFields();
+
+    ASSERT_TRUE(this->compareBC());
+    ASSERT_EQ(this->solver->dt, this->solver2->dt);
+    ASSERT_TRUE(this->comparePml(this->maxAbsoluteError));
+    ASSERT_TRUE(this->compareGenerator());
+    ASSERT_TRUE(this->compareFields(this->maxAbsoluteError));
+}
 
 class SaveLoadSolverAnalyticalFieldSolver : public BaseFixture {
 public:


### PR DESCRIPTION
### Content
Field solver's boundary conditions are now stored in pairs:
```cpp
std::array<std::pair<   
        std::unique_ptr<FieldBoundaryCondition<typename SchemeParams::GridType>>, // +Axis
        std::unique_ptr<FieldBoundaryCondition<typename SchemeParams::GridType>> // -Axis
        >, 3> boundaryConditions;
```

This change allows the solver to have different boundary conditions on opposite sides over the same axis. This change does not affect the functionality of old boundary condition classes. Save/loading systems were adjusted to properly handle all 6 boundary conditions.

### Testing
* A version of `MixedPeriodicAndReflectBoundaryConditionTest` with directional reflect boundary conditions: [PASSED]
* Save/load tests were adjusted to properly test saving and loading of all 6 boundary conditions: [PASSED]

### Reasoning
These changes are required for the upcoming MPI implementation.